### PR TITLE
Traces on canvas

### DIFF
--- a/src/app/run/[id]/_animation_options.tsx
+++ b/src/app/run/[id]/_animation_options.tsx
@@ -26,6 +26,7 @@ function Times({ className }: { className?: string }) {
 }
 
 const intervalMs = 1000 / 30;
+// const intervalMs = 1000 / 60;
 
 function PlayButton({ useViewOptionsStore }: { useViewOptionsStore: UseViewOptionsStore }) {
     const isPlaying = useViewOptionsStore((s) => s.isPlaying);

--- a/src/app/run/[id]/_viewOptionsStore.tsx
+++ b/src/app/run/[id]/_viewOptionsStore.tsx
@@ -88,7 +88,6 @@ function createViewOptionsStore(searchParams: ReadonlyURLSearchParams) {
 
                     function recalcNextSplit() {
                         set((state) => {
-                            console.log('recalcNextSplit');
                             const { filteredSplits, animationMsIntoGame, nextSplitIndex: oldNextSplitIndex } = state;
                             const nextSplitIndex = filteredSplits?.findIndex(
                                 (split, index) =>

--- a/src/lib/viz/charts/hk-map.tsx
+++ b/src/lib/viz/charts/hk-map.tsx
@@ -98,14 +98,14 @@ export function HKMap({ className, useViewOptionsStore }: HKMapProps) {
 
         rootG.current = svg.current.append('g').attr('data-group', 'root');
 
-        rootG.current
-            .append('rect')
-            .attr('width', '100%')
-            .attr('height', '100%')
-            .attr('fill', 'yellow')
-            .attr('fill-opacity', 0.2)
-            .attr('x', mapVisualExtends.min.x)
-            .attr('y', mapVisualExtends.min.y);
+        // rootG.current
+        //     .append('rect')
+        //     .attr('width', '100%')
+        //     .attr('height', '100%')
+        //     .attr('fill', 'yellow')
+        //     .attr('fill-opacity', 0.2)
+        //     .attr('x', mapVisualExtends.min.x)
+        //     .attr('y', mapVisualExtends.min.y);
 
         roomDataEnter.current = rootG.current
             .append('g')

--- a/src/lib/viz/charts/hk-map.tsx
+++ b/src/lib/viz/charts/hk-map.tsx
@@ -98,6 +98,15 @@ export function HKMap({ className, useViewOptionsStore }: HKMapProps) {
 
         rootG.current = svg.current.append('g').attr('data-group', 'root');
 
+        rootG.current
+            .append('rect')
+            .attr('width', '100%')
+            .attr('height', '100%')
+            .attr('fill', 'yellow')
+            .attr('fill-opacity', 0.2)
+            .attr('x', mapVisualExtends.min.x)
+            .attr('y', mapVisualExtends.min.y);
+
         roomDataEnter.current = rootG.current
             .append('g')
             .attr('data-group', 'rooms')

--- a/src/lib/viz/charts/hk-map.tsx
+++ b/src/lib/viz/charts/hk-map.tsx
@@ -8,6 +8,7 @@ import { mapVisualExtends } from '../map-data/map-extends';
 import { mainRoomDataBySceneName, roomData, type RoomInfo } from '../map-data/rooms';
 import { Bounds } from '../types/bounds';
 import { MapLegend } from './legend';
+import { HKMapTraces } from './traces-canvas';
 import { useMapRooms } from './use-map-rooms';
 import { useMapTraces } from './use-traces';
 
@@ -53,6 +54,7 @@ export function HKMap({ className, useViewOptionsStore }: HKMapProps) {
     const rootG = useRef<d3.Selection<SVGGElement, unknown, null, undefined>>();
 
     const zoom = useRef<d3.ZoomBehavior<SVGSVGElement, unknown>>();
+    const tracesZoomHandler = useRef<(event: any) => void>();
 
     const animatedTraceG = useRef<d3.Selection<SVGGElement, unknown, null, undefined>>();
     const knightPinG = useRef<d3.Selection<SVGGElement, unknown, null, undefined>>();
@@ -82,6 +84,7 @@ export function HKMap({ className, useViewOptionsStore }: HKMapProps) {
             .on('zoom', (event) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
                 rootG.current!.attr('transform', event.transform);
+                tracesZoomHandler.current?.(event);
             });
         svg.current = d3
             .select(containerRef.current)
@@ -157,6 +160,11 @@ export function HKMap({ className, useViewOptionsStore }: HKMapProps) {
         <div className={cn('relative', className)} ref={containerRef}>
             {false && <HKMapZoom useViewOptionsStore={useViewOptionsStore} svg={svg} zoom={zoom} />}
             <MapLegend useViewOptionsStore={useViewOptionsStore} />
+            <HKMapTraces
+                useViewOptionsStore={useViewOptionsStore}
+                containerRef={containerRef}
+                zoomHandler={tracesZoomHandler}
+            />
         </div>
     );
 }

--- a/src/lib/viz/charts/traces-canvas.tsx
+++ b/src/lib/viz/charts/traces-canvas.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef, type MutableRefObject, type RefObject } from 'react';
+import useEvent from 'react-use-event-hook';
+import { type UseViewOptionsStore } from '~/app/run/[id]/_viewOptionsStore';
+import { mapVisualExtends } from '../map-data/map-extends';
+import { PlayerPositionEvent } from '../recording-files/events/player-position-event';
+
+export interface HKMapTracesProps {
+    useViewOptionsStore: UseViewOptionsStore;
+    containerRef: RefObject<HTMLDivElement>;
+    zoomHandler: MutableRefObject<((event: any) => void) | undefined>;
+}
+
+const EMPTY_ARRAY = [] as const;
+
+export function HKMapTraces({ useViewOptionsStore, containerRef, zoomHandler }: HKMapTracesProps) {
+    const zoomPosition = useRef({ offsetX: 0, offsetY: 0, scale: 1 });
+    const animationMsIntoGame = useViewOptionsStore((s) => s.animationMsIntoGame);
+    const traceAnimationLengthMs = useViewOptionsStore((s) => s.traceAnimationLengthMs);
+    const traceVisibility = useViewOptionsStore((s) => s.traceVisibility);
+    const recording = useViewOptionsStore((s) => s.recording);
+
+    // always 0 when traceVisibility !== 'animated' since that avoids running the effect when animating, but traces are not animating
+    const animationMsIntoGameForTrace = traceVisibility === 'animated' ? animationMsIntoGame : 0;
+
+    const positionEvents = useMemo(() => {
+        if (!recording) return EMPTY_ARRAY;
+
+        return recording.events.filter((event): event is PlayerPositionEvent => {
+            return (
+                event instanceof PlayerPositionEvent &&
+                event.mapPosition != null &&
+                event.previousPlayerPositionEventWithMapPosition?.mapPosition != null &&
+                !event.previousPlayerPositionEventWithMapPosition.mapPosition.equals(event.mapPosition)
+            );
+        });
+    }, [recording]);
+
+    const canvas = useRef<HTMLCanvasElement>(null);
+
+    const draw = useEvent(() => {
+        if (!canvas.current) return;
+        const xScale = (zoomPosition.current.scale * canvas.current.width) / mapVisualExtends.size.x;
+
+        const yScale = (zoomPosition.current.scale * canvas.current.height) / mapVisualExtends.size.y;
+
+        const xOffset = -mapVisualExtends.min.x + zoomPosition.current.offsetX;
+        const yOffset = -mapVisualExtends.min.y + zoomPosition.current.offsetY;
+        function x(v: number) {
+            return v * xScale + xOffset;
+        }
+        function y(v: number) {
+            return v * yScale + yOffset;
+        }
+
+        const ctx = canvas.current.getContext('2d');
+        if (!ctx) return;
+
+        ctx.clearRect(0, 0, canvas.current.width, canvas.current.height);
+
+        ctx.fillStyle = 'red';
+        ctx.strokeStyle = 'red';
+
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        for (const event of positionEvents) {
+            ctx.lineTo(x(event.mapPosition!.x), y(event.mapPosition!.y));
+        }
+        ctx.stroke();
+    });
+
+    useEffect(() => {
+        function containerSizeChanged() {
+            if (!canvas.current || !containerRef.current) return;
+
+            canvas.current.width = containerRef.current.offsetWidth;
+            canvas.current.height = containerRef.current.offsetHeight;
+
+            // canvas.current
+            //     .attr('width', containerRef.current.offsetWidth)
+            //     .attr('height', containerRef.current.offsetHeight);
+            draw();
+        }
+        containerSizeChanged();
+
+        const resizeObserver = new ResizeObserver(containerSizeChanged);
+
+        resizeObserver.observe(containerRef.current!);
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [containerRef, draw]);
+
+    useEffect(() => {
+        zoomHandler.current = (event) => {
+            zoomPosition.current = {
+                offsetX: event.transform.x,
+                offsetY: event.transform.y,
+                scale: event.transform.k,
+            };
+            draw();
+        };
+    }, [draw, zoomHandler]);
+
+    return <canvas ref={canvas} className="pointer-events-none absolute inset-0" />;
+}

--- a/src/lib/viz/charts/traces-canvas.tsx
+++ b/src/lib/viz/charts/traces-canvas.tsx
@@ -39,17 +39,32 @@ export function HKMapTraces({ useViewOptionsStore, containerRef, zoomHandler }: 
 
     const draw = useEvent(() => {
         if (!canvas.current) return;
-        const xScale = (zoomPosition.current.scale * canvas.current.width) / mapVisualExtends.size.x;
 
-        const yScale = (zoomPosition.current.scale * canvas.current.height) / mapVisualExtends.size.y;
+        const boundsAspectRatio = mapVisualExtends.size.x / mapVisualExtends.size.y;
+        const canvasAspectRatio = canvas.current.width / canvas.current.height;
 
-        const xOffset = -mapVisualExtends.min.x + zoomPosition.current.offsetX;
-        const yOffset = -mapVisualExtends.min.y + zoomPosition.current.offsetY;
+        const mapDistanceToPixels =
+            boundsAspectRatio > canvasAspectRatio
+                ? canvas.current.width / mapVisualExtends.size.x
+                : canvas.current.height / mapVisualExtends.size.y;
+
+        const scaler = zoomPosition.current.scale * mapDistanceToPixels;
+
+        // const xCenter =
+
+        const xOffset =
+            canvas.current.width / 2 -
+            mapVisualExtends.center.x * mapDistanceToPixels +
+            zoomPosition.current.offsetX * mapDistanceToPixels;
+        const yOffset =
+            canvas.current.height / 2 -
+            mapVisualExtends.center.y * mapDistanceToPixels +
+            zoomPosition.current.offsetY * mapDistanceToPixels;
         function x(v: number) {
-            return v * xScale + xOffset;
+            return v * scaler + xOffset;
         }
         function y(v: number) {
-            return v * yScale + yOffset;
+            return v * scaler + yOffset;
         }
 
         const ctx = canvas.current.getContext('2d');

--- a/src/lib/viz/charts/use-traces.tsx
+++ b/src/lib/viz/charts/use-traces.tsx
@@ -23,6 +23,7 @@ const SCALED_LINE_WIDTH = 0.05 * SCALE_FACTOR;
 const SCALED_KNIGHT_PIN_SIZE = 0.75 * SCALE_FACTOR;
 
 export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }: Props) {
+    // return;
     const animatedTraceChunks = useRef<
         {
             minMsIntoGame: number;

--- a/src/lib/viz/charts/use-traces.tsx
+++ b/src/lib/viz/charts/use-traces.tsx
@@ -23,7 +23,6 @@ const SCALED_LINE_WIDTH = 0.05 * SCALE_FACTOR;
 const SCALED_KNIGHT_PIN_SIZE = 0.75 * SCALE_FACTOR;
 
 export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }: Props) {
-    return;
     const animatedTraceChunks = useRef<
         {
             minMsIntoGame: number;
@@ -38,6 +37,7 @@ export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }
     const traceAnimationLengthMs = useViewOptionsStore((s) => s.traceAnimationLengthMs);
     const traceVisibility = useViewOptionsStore((s) => s.traceVisibility);
     const recording = useViewOptionsStore((s) => s.recording);
+    const displayVersion = useViewOptionsStore((s) => s.displayVersion);
 
     // always 0 when traceVisibility !== 'animated' since that avoids running the effect when animating, but traces are not animating
     const animationMsIntoGameForTrace = traceVisibility === 'animated' ? animationMsIntoGame : 0;
@@ -45,14 +45,17 @@ export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }
     useEffect(() => {
         if (!recording) return;
 
-        const positionEvents = recording.events.filter((event): event is PlayerPositionEvent => {
-            return (
-                event instanceof PlayerPositionEvent &&
-                event.mapPosition != null &&
-                event.previousPlayerPositionEventWithMapPosition?.mapPosition != null &&
-                !event.previousPlayerPositionEventWithMapPosition.mapPosition.equals(event.mapPosition)
-            );
-        });
+        const positionEvents =
+            displayVersion === 'v1'
+                ? recording.events.filter((event): event is PlayerPositionEvent => {
+                      return (
+                          event instanceof PlayerPositionEvent &&
+                          event.mapPosition != null &&
+                          event.previousPlayerPositionEventWithMapPosition?.mapPosition != null &&
+                          !event.previousPlayerPositionEventWithMapPosition.mapPosition.equals(event.mapPosition)
+                      );
+                  })
+                : [];
 
         const positionEventChunks = chunk(positionEvents, 100);
         animatedTraceChunks.current?.forEach((chunk) => chunk.group.remove());
@@ -104,7 +107,7 @@ export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }
         });
 
         animatedTraceG.current!.selectAll('path').remove();
-    }, [recording, animatedTraceG]);
+    }, [recording, animatedTraceG, displayVersion]);
 
     useEffect(() => {
         knightPin.current = knightPinG
@@ -115,7 +118,8 @@ export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }
             .attr('width', SCALED_KNIGHT_PIN_SIZE)
             .attr('height', SCALED_KNIGHT_PIN_SIZE)
             .attr('preserveAspectRatio', 'none')
-            .style('pointer-events', 'none');
+            .style('pointer-events', 'none')
+            .attr('visibility', 'hidden');
     }, [knightPinG]);
 
     useEffect(() => {

--- a/src/lib/viz/charts/use-traces.tsx
+++ b/src/lib/viz/charts/use-traces.tsx
@@ -23,7 +23,7 @@ const SCALED_LINE_WIDTH = 0.05 * SCALE_FACTOR;
 const SCALED_KNIGHT_PIN_SIZE = 0.75 * SCALE_FACTOR;
 
 export function useMapTraces({ useViewOptionsStore, animatedTraceG, knightPinG }: Props) {
-    // return;
+    return;
     const animatedTraceChunks = useRef<
         {
             minMsIntoGame: number;


### PR DESCRIPTION
Since traces using svg elements do consume a lot of ram, and make dragging and zooming on the map rather slow on phones, and somewhat slow on other devices too, especially for long gameplays. 

This moves the traces to be drawn as a canvas. Much better performance in my testing and ram consumption decreased too.